### PR TITLE
refactor: use @dhis2/cli-helpers-engine to support heirarchichal CLI

### DIFF
--- a/bin/d2-packages
+++ b/bin/d2-packages
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+const { makeEntryPoint } = require('@dhis2/cli-helpers-engine')
+const command = require('..');
+
+makeEntryPoint(command).parse();

--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+const { namespace } = require('@dhis2/cli-helpers-engine')
+
+const command = namespace('packages', {
+    desc: 'Manage DHIS2 packages',
+    aliases: 'pkg',
+    builder: require('./lib/cmds'),
+})
+
+module.exports = command

--- a/lib/cmds.js
+++ b/lib/cmds.js
@@ -1,15 +1,3 @@
-module.exports = require('yargs')
-    .usage('usage: $0 <command> [options]')
-    .commandDir('cmds')
-    .command(
-        'code-style [options]',
-        'Use code-style to format code.',
-        require('@dhis2/code-style/lib/cmds/fmt-code.js')
-    )
-    .command(
-        'commit-style [options]',
-        'Use commit-style to format commits.',
-        require('@dhis2/code-style/lib/cmds/fmt-commit.js')
-    )
-    .demandCommand()
-    .help()
+module.exports = yargs => {
+    yargs.commandDir('cmds')
+}

--- a/lib/cmds/build.js
+++ b/lib/cmds/build.js
@@ -5,6 +5,7 @@ const { collect } = require('@vardevs/io')
 const { bold } = require('../colors.js')
 
 const die = require('../die.js')
+const getContext = require('../getContext')
 
 const log = require('@vardevs/log')({
     level: require('../loglevel.js'),
@@ -23,8 +24,8 @@ This command does not need the packages to be linked, so useful in a CI environm
 
 exports.builder = {}
 
-exports.handler = function(argv) {
-    const { cwd, is_monorepo, root_dir, tool } = argv
+exports.handler = async function() {
+    const { cwd, tool } = await getContext()
     const pkgs = collect(cwd, {
         blacklist: ['node_modules', '.git', 'src', 'build'],
         whitelist: ['package.json'],

--- a/lib/cmds/copy.js
+++ b/lib/cmds/copy.js
@@ -13,6 +13,8 @@ const log = require('@vardevs/log')({
 const { collect } = require('@vardevs/io')
 const { dep_graph } = require('../deps.js')
 
+const getContext = require('../getContext')
+
 exports.command = 'copy'
 
 exports.describe = `Copies 'package.json' for packages from the base directory to the build directory.
@@ -30,8 +32,8 @@ This is to signify that we should publish from the build directory. If one accid
 
 exports.builder = {}
 
-exports.handler = async function(argv) {
-    const { cwd } = argv
+exports.handler = async function() {
+    const { cwd } = await getContext()
     const packages = collect(cwd, {
         blacklist: ['node_modules', '.git', 'src', 'build'],
         whitelist: ['package.json'],

--- a/lib/cmds/exec.js
+++ b/lib/cmds/exec.js
@@ -12,6 +12,7 @@ const log = require('@vardevs/log')({
 
 const die = require('../die.js')
 const { bold } = require('../colors.js')
+const getContext = require('../getContext')
 
 exports.command = 'exec <command> [cmdargs..]'
 
@@ -27,8 +28,9 @@ exports.builder = {
     },
 }
 
-exports.handler = function(argv) {
-    const { cwd, cmdargs, command } = argv
+exports.handler = async function(argv) {
+    const { cmdargs, command } = argv
+    const { cwd } = await getContext()
 
     const packages = collect(cwd, {
         blacklist: ['node_modules', '.git', 'src', 'build'],

--- a/lib/cmds/install.js
+++ b/lib/cmds/install.js
@@ -10,6 +10,7 @@ const exec = require('./exec').handler
 
 const die = require('../die.js')
 const { bold } = require('../colors.js')
+const getContext = require('../getContext')
 
 exports.command = 'install'
 
@@ -18,8 +19,8 @@ exports.describe =
 
 exports.builder = {}
 
-exports.handler = function(argv) {
-    const { cwd, is_monorepo, root_dir, tool } = argv
+exports.handler = async function(argv) {
+    const { is_monorepo, root_dir, tool } = await getContext()
     const newargv = Object.assign({}, argv, {
         command: tool,
         cmdargs: ['install'],

--- a/lib/cmds/link.js
+++ b/lib/cmds/link.js
@@ -2,6 +2,7 @@
 
 const path = require('path')
 const { spawn } = require('child_process')
+const getContext = require('../getContext')
 
 const log = require('@vardevs/log')({
     level: require('../loglevel.js'),
@@ -48,7 +49,7 @@ The link command attempts to figure out which packages need links to which other
 exports.builder = {}
 
 exports.handler = async function(argv) {
-    const { cwd, is_monorepo, root_dir, tool } = argv
+    const { cwd, is_monorepo, root_dir, tool } = await getContext()
     await copy_package_json(argv)
 
     const pkgs = collect(cwd, {

--- a/lib/cmds/release.js
+++ b/lib/cmds/release.js
@@ -1,4 +1,5 @@
 const std_version = require('standard-version')
+const getContext = require('../getContext')
 
 exports.command = 'release [options]'
 
@@ -25,11 +26,11 @@ exports.builder = {
         describe: 'Suppress output.',
         default: false,
         alias: ['q'],
-    }
+    },
 }
 
-exports.handler = function(argv) {
-    const { cwd, is_monorepo, root_dir, tool } = argv
+exports.handler = async function(argv) {
+    const { root_dir } = await getContext()
 
     const options = {
         noVerify: true,

--- a/lib/getContext.js
+++ b/lib/getContext.js
@@ -1,18 +1,13 @@
-#!/usr/bin/env node
 const path = require('path')
 const fs = require('fs-extra')
 
-const die = require('./lib/die.js')
+const die = require('./die.js')
 
 const log = require('@vardevs/log')({
-    level: require('./lib/loglevel.js'),
+    level: require('./loglevel.js'),
     prefix: 'packages',
 })
-
-const { reverse } = require('./lib/colors.js')
-const { is_monorepo, mono_path } = require('./lib/mono.js')
-
-const cmds = require('./lib/cmds.js')
+const { is_monorepo, mono_path } = require('./mono.js')
 
 const repoDir = process.cwd()
 
@@ -52,24 +47,16 @@ async function setup(cwd) {
     return pwd
 }
 
-async function main() {
-    log.info(reverse(`     DHIS2 Packages     `))
-
+module.exports = async function getContext() {
     await is_package(repoDir)
 
     const npm_yarn = await tool(repoDir)
     const cwd = await setup(repoDir)
 
-    cmds.config({
+    return {
         cwd: cwd,
         is_monorepo: repoDir !== cwd,
         root_dir: repoDir,
         tool: npm_yarn,
-    })
-
-    const argv = cmds.argv
-    log.debug(argv)
+    }
 }
-
-// start it!
-main()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
-    "name": "@dhis2/packages",
-    "version": "1.3.0",
+    "name": "@dhis2/cli-packages",
+    "version": "2.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@commitlint/config-conventional": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-7.1.2.tgz",
-            "integrity": "sha512-DmA4ixkpv03qA1TVs1Bl25QsVym2bPL6pKapesALWIVggG3OpwqGZ55vN75Tx8xZoG7LFKrVyrt7kwhA7X8njQ=="
+            "integrity": "sha512-DmA4ixkpv03qA1TVs1Bl25QsVym2bPL6pKapesALWIVggG3OpwqGZ55vN75Tx8xZoG7LFKrVyrt7kwhA7X8njQ==",
+            "dev": true
         },
         "@commitlint/ensure": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-7.2.0.tgz",
             "integrity": "sha512-j2AJE4eDeLP6O/Z1CdPwEXAzcrRRoeeHLuvW8bldQ4J2nHiX9hzmSe87H87Ob8Avm+zIegsqVPGaBAtRmbODYw==",
+            "dev": true,
             "requires": {
                 "lodash.camelcase": "4.3.0",
                 "lodash.kebabcase": "4.1.1",
@@ -25,6 +27,7 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-7.1.2.tgz",
             "integrity": "sha512-EP/SqX2U2L4AQHglZ2vGM1pvHJOh3sbYtHn1QhtllqEpsdmhuNpVPSGHP/r9OD2h4i90vtnWgZQoskt2MkbknA==",
+            "dev": true,
             "requires": {
                 "babel-runtime": "6.26.0"
             }
@@ -33,6 +36,7 @@
             "version": "7.2.1",
             "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-7.2.1.tgz",
             "integrity": "sha512-1YcL+ZWB8V52oDFQBhSBJjiJOZDt4Vl06O5TkG70BMpre3EQru5KYIN16eEPqfihNw0bj8gSIWcf87Gvh3OrOw==",
+            "dev": true,
             "requires": {
                 "babel-runtime": "^6.23.0",
                 "chalk": "^2.0.1"
@@ -42,6 +46,7 @@
             "version": "7.2.1",
             "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-7.2.1.tgz",
             "integrity": "sha512-3DsEEKRnj8Bv9qImsxWcGf9BwerDnk5Vs+oK6ELzIwkndHaAZLHyATjmaz/rsc+U+DWiVjgKrrw3xvd/UsoazA==",
+            "dev": true,
             "requires": {
                 "semver": "5.6.0"
             }
@@ -50,6 +55,7 @@
             "version": "7.2.1",
             "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-7.2.1.tgz",
             "integrity": "sha512-rM7nUyNUJyuKw1MTwJG/wk4twB5YCAG2wzJMn5NqVpGD/qmLOzlZoBl0+CYmuOsbIRAA2rlEV6KZHBk9tTfAdQ==",
+            "dev": true,
             "requires": {
                 "@commitlint/is-ignored": "^7.2.1",
                 "@commitlint/parse": "^7.1.2",
@@ -62,6 +68,7 @@
             "version": "7.2.1",
             "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.2.1.tgz",
             "integrity": "sha512-FnfmfhPGJqGwILVRznduBejOicNey6p/byfcyxtcBkN2+X96gDuNtqcnGcngCrzPIAgaIrQQcTQDA1/KMtW21A==",
+            "dev": true,
             "requires": {
                 "@commitlint/execute-rule": "^7.1.2",
                 "@commitlint/resolve-extends": "^7.1.2",
@@ -78,6 +85,7 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
                     "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+                    "dev": true,
                     "requires": {
                         "is-directory": "^0.3.1",
                         "js-yaml": "^3.9.0",
@@ -88,19 +96,22 @@
                 "resolve-from": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
                 }
             }
         },
         "@commitlint/message": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-7.1.2.tgz",
-            "integrity": "sha512-6FQeK5LAs1Bde6W/jULg+I/XZhj3gbqCWlS2Q11A2JbaTRpRJZzm7WdD9nK3I0+De41EOqW2t4mBnrpio3o1Zg=="
+            "integrity": "sha512-6FQeK5LAs1Bde6W/jULg+I/XZhj3gbqCWlS2Q11A2JbaTRpRJZzm7WdD9nK3I0+De41EOqW2t4mBnrpio3o1Zg==",
+            "dev": true
         },
         "@commitlint/parse": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-7.1.2.tgz",
             "integrity": "sha512-wrdLwJZL3cs89MfgPtnbbKByijUo3Wrug55aTke5k/F0XNxGaDaNJyH4QXgidgXk57r2t4NJVAKwjnY4wjfNwg==",
+            "dev": true,
             "requires": {
                 "conventional-changelog-angular": "^1.3.3",
                 "conventional-commits-parser": "^2.1.0"
@@ -110,6 +121,7 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-7.1.2.tgz",
             "integrity": "sha512-sarYQgfTay2Eu7onHz53EYyRw7pI5QmLE7tP5Ri9op6eu4LadjSoA/4dfc+VE7avsq21J2ewSbz+9f0uvhDxgg==",
+            "dev": true,
             "requires": {
                 "@commitlint/top-level": "^7.1.2",
                 "@marionebl/sander": "^0.6.0",
@@ -121,6 +133,7 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-7.1.2.tgz",
             "integrity": "sha512-zwbifMB9DeHP4sYQdrkx+XJh5Q1lyP/OdlErUCC34NV4Lkxw/XxXF4St3e+y1X28/SgrEc2XSOS6n/vQQfUlLA==",
+            "dev": true,
             "requires": {
                 "babel-runtime": "6.26.0",
                 "lodash.merge": "4.6.1",
@@ -133,7 +146,8 @@
                 "resolve-from": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
                 }
             }
         },
@@ -141,6 +155,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-7.2.0.tgz",
             "integrity": "sha512-c15Q9H5iYE9fnncLnFnMuvPLYA/i0pve5moV0uxJJGr4GgJoBKyldd4CCDhoE80C1k8ABuqr2o2qsopzVEp3Ww==",
+            "dev": true,
             "requires": {
                 "@commitlint/ensure": "^7.2.0",
                 "@commitlint/message": "^7.1.2",
@@ -151,20 +166,104 @@
         "@commitlint/to-lines": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-7.1.2.tgz",
-            "integrity": "sha512-Nz3qZwrIEYiN9v/ThJqXAwu4X5+hvT9H8yRPHfjc538R8WhwEfhvym7/4YznDHSvWrQgwqtNPdrb6b2OSBsHmg=="
+            "integrity": "sha512-Nz3qZwrIEYiN9v/ThJqXAwu4X5+hvT9H8yRPHfjc538R8WhwEfhvym7/4YznDHSvWrQgwqtNPdrb6b2OSBsHmg==",
+            "dev": true
         },
         "@commitlint/top-level": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-7.1.2.tgz",
             "integrity": "sha512-YKugOAKy3hgM/ITezPp7Ns51U3xoJfuOsVnMGW4oDcHLhuQ/Qd58ROv/Hgedtk8HugKX3DdZ8XoEnRG70RDGqQ==",
+            "dev": true,
             "requires": {
                 "find-up": "^2.1.0"
+            }
+        },
+        "@dhis2/cli-helpers-engine": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@dhis2/cli-helpers-engine/-/cli-helpers-engine-0.10.1.tgz",
+            "integrity": "sha512-HEvswPHCF+y1N4L5ZEdBDoXWc0ijfGb5RDYNlAhab6yXzCZpbDk339jnLF3sYjKZ1fFFWC3uc7wthdywfqeGuw==",
+            "requires": {
+                "chalk": "^2.4.2",
+                "mkdirp": "^0.5.1",
+                "request": "^2.88.0",
+                "rimraf": "^2.6.3",
+                "tar": "^4.4.8",
+                "update-notifier": "^2.5.0",
+                "yargs": "^12.0.5"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+                    "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                }
+            }
+        },
+        "@dhis2/cli-style": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@dhis2/cli-style/-/cli-style-0.10.1.tgz",
+            "integrity": "sha512-5UkcgksX0+KeFl2EAGkFGmpp1KnxSmnA63NsedonTMuOujQsTfaxFgVBDEG8e0oYAJNwSOonWJMohOZWVfauMg==",
+            "dev": true,
+            "requires": {
+                "@dhis2/cli-helpers-engine": "^0.10.1",
+                "@dhis2/code-style": "^1.7.1"
+            },
+            "dependencies": {
+                "@dhis2/cli-helpers-engine": {
+                    "version": "0.10.1",
+                    "resolved": "https://registry.npmjs.org/@dhis2/cli-helpers-engine/-/cli-helpers-engine-0.10.1.tgz",
+                    "integrity": "sha512-HEvswPHCF+y1N4L5ZEdBDoXWc0ijfGb5RDYNlAhab6yXzCZpbDk339jnLF3sYjKZ1fFFWC3uc7wthdywfqeGuw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.2",
+                        "mkdirp": "^0.5.1",
+                        "request": "^2.88.0",
+                        "rimraf": "^2.6.3",
+                        "tar": "^4.4.8",
+                        "update-notifier": "^2.5.0",
+                        "yargs": "^12.0.5"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+                    "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                }
             }
         },
         "@dhis2/code-style": {
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/@dhis2/code-style/-/code-style-1.7.1.tgz",
             "integrity": "sha512-tXj4meoK9L/pmS0SUzzYoB980nwmeCz5YW3GBoWdVI4aFJSR9qn8XtbAXGPsr14ExZoqvFFpA8VGaN6RTCFQqA==",
+            "dev": true,
             "requires": {
                 "@commitlint/config-conventional": "^7.1.2",
                 "@commitlint/format": "^7.2.1",
@@ -179,6 +278,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
             "integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.3",
                 "mkdirp": "^0.5.1",
@@ -208,6 +308,25 @@
                 "through": ">=2.2.7 <3"
             }
         },
+        "ajv": {
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+            "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+            "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ansi-align": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+            "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+            "requires": {
+                "string-width": "^2.0.0"
+            }
+        },
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -225,6 +344,7 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
             }
@@ -244,6 +364,19 @@
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
             "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
         },
+        "asn1": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
         "async": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
@@ -252,10 +385,26 @@
                 "lodash": "^4.17.10"
             }
         },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "aws4": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+        },
         "babel-runtime": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "dev": true,
             "requires": {
                 "core-js": "^2.4.0",
                 "regenerator-runtime": "^0.11.0"
@@ -265,6 +414,28 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
+        "boxen": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+            "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+            "requires": {
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^2.0.0"
+            }
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -305,7 +476,7 @@
         },
         "callsites": {
             "version": "2.0.0",
-            "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
             "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
             "dev": true
         },
@@ -324,6 +495,16 @@
                 "quick-lru": "^1.0.0"
             }
         },
+        "capture-stack-trace": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+            "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
         "chalk": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -334,11 +515,20 @@
                 "supports-color": "^5.3.0"
             }
         },
+        "chownr": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+            "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+        },
         "ci-info": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-            "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-            "dev": true
+            "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+        },
+        "cli-boxes": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+            "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
         },
         "cliui": {
             "version": "4.1.0",
@@ -383,6 +573,14 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
+        "combined-stream": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+            "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
         "commander": {
             "version": "2.17.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
@@ -412,6 +610,29 @@
                 "inherits": "^2.0.3",
                 "readable-stream": "^2.2.2",
                 "typedarray": "^0.0.6"
+            }
+        },
+        "configstore": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+            "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+            "requires": {
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
+            },
+            "dependencies": {
+                "dot-prop": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+                    "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+                    "requires": {
+                        "is-obj": "^1.0.0"
+                    }
+                }
             }
         },
         "conventional-changelog": {
@@ -816,7 +1037,8 @@
         "core-js": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
-            "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw=="
+            "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw==",
+            "dev": true
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -835,6 +1057,14 @@
                 "parse-json": "^4.0.0"
             }
         },
+        "create-error-class": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+            "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+            "requires": {
+                "capture-stack-trace": "^1.0.0"
+            }
+        },
         "cross-spawn": {
             "version": "6.0.5",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -846,6 +1076,11 @@
                 "shebang-command": "^1.2.0",
                 "which": "^1.2.9"
             }
+        },
+        "crypto-random-string": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+            "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
         },
         "currently-unhandled": {
             "version": "0.4.1",
@@ -861,6 +1096,14 @@
             "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
             "requires": {
                 "number-is-nan": "^1.0.0"
+            }
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "requires": {
+                "assert-plus": "^1.0.0"
             }
         },
         "dateformat": {
@@ -894,6 +1137,11 @@
             "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
             "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
         },
+        "deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+        },
         "define-properties": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -906,6 +1154,11 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
             "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "dot-prop": {
             "version": "3.0.0",
@@ -922,6 +1175,20 @@
             "requires": {
                 "find-up": "^2.1.0",
                 "minimatch": "^3.0.4"
+            }
+        },
+        "duplexer3": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+        },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "end-of-stream": {
@@ -971,7 +1238,8 @@
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
         },
         "execa": {
             "version": "0.10.0",
@@ -986,6 +1254,26 @@
                 "signal-exit": "^3.0.0",
                 "strip-eof": "^1.0.0"
             }
+        },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        },
+        "fast-deep-equal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
         "figures": {
             "version": "1.7.0",
@@ -1012,6 +1300,21 @@
                 "is-callable": "^1.1.3"
             }
         },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+        },
+        "form-data": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            }
+        },
         "fs-access": {
             "version": "1.0.1",
             "resolved": "http://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
@@ -1028,6 +1331,14 @@
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
                 "universalify": "^0.1.0"
+            }
+        },
+        "fs-minipass": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+            "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+            "requires": {
+                "minipass": "^2.2.1"
             }
         },
         "fs.realpath": {
@@ -1214,6 +1525,14 @@
             "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
             "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
         "git-raw-commits": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
@@ -1280,6 +1599,24 @@
                 "ini": "^1.3.4"
             }
         },
+        "got": {
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+            "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+            "requires": {
+                "create-error-class": "^3.0.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-redirect": "^1.0.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "lowercase-keys": "^1.0.0",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "unzip-response": "^2.0.1",
+                "url-parse-lax": "^1.0.0"
+            }
+        },
         "graceful-fs": {
             "version": "4.1.15",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
@@ -1294,6 +1631,20 @@
                 "optimist": "^0.6.1",
                 "source-map": "^0.6.1",
                 "uglify-js": "^3.1.4"
+            }
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "requires": {
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
             }
         },
         "has": {
@@ -1322,17 +1673,27 @@
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
             "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
         },
-        "husky": {
+        "http-signature": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-1.2.0.tgz",
-            "integrity": "sha512-/ib3+iycykXC0tYIxsyqierikVa9DA2DrT32UEirqNEFVqOj1bFMTgP3jAz8HM7FgC/C8pc/BTUa9MV2GEkZaA==",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            }
+        },
+        "husky": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-1.3.1.tgz",
+            "integrity": "sha512-86U6sVVVf4b5NYSZ0yvv88dRgBSSXXmHaiq5pP4KDj5JVzdwKgBjEtUPOm8hcoytezFwbU+7gotXNhpHdystlg==",
             "dev": true,
             "requires": {
-                "cosmiconfig": "^5.0.6",
+                "cosmiconfig": "^5.0.7",
                 "execa": "^1.0.0",
                 "find-up": "^3.0.0",
                 "get-stdin": "^6.0.0",
-                "is-ci": "^1.2.1",
+                "is-ci": "^2.0.0",
                 "pkg-dir": "^3.0.0",
                 "please-upgrade-node": "^3.1.1",
                 "read-pkg": "^4.0.1",
@@ -1340,6 +1701,12 @@
                 "slash": "^2.0.0"
             },
             "dependencies": {
+                "ci-info": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+                    "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+                    "dev": true
+                },
                 "execa": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -1379,6 +1746,15 @@
                         "pump": "^3.0.0"
                     }
                 },
+                "is-ci": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+                    "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+                    "dev": true,
+                    "requires": {
+                        "ci-info": "^2.0.0"
+                    }
+                },
                 "locate-path": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -1390,9 +1766,9 @@
                     }
                 },
                 "p-limit": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-                    "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+                    "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
                     "dev": true,
                     "requires": {
                         "p-try": "^2.0.0"
@@ -1435,6 +1811,16 @@
                 "caller-path": "^2.0.0",
                 "resolve-from": "^3.0.0"
             }
+        },
+        "import-lazy": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+            "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
         },
         "indent-string": {
             "version": "3.2.0",
@@ -1487,7 +1873,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
             "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-            "dev": true,
             "requires": {
                 "ci-info": "^1.5.0"
             }
@@ -1500,7 +1885,8 @@
         "is-directory": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-            "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+            "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+            "dev": true
         },
         "is-finite": {
             "version": "1.0.2",
@@ -1515,15 +1901,42 @@
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
             "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
+        "is-installed-globally": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+            "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+            "requires": {
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
+            }
+        },
+        "is-npm": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+            "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+        },
         "is-obj": {
             "version": "1.0.1",
             "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
         },
+        "is-path-inside": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+            "requires": {
+                "path-is-inside": "^1.0.1"
+            }
+        },
         "is-plain-obj": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
             "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+        },
+        "is-redirect": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+            "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
         },
         "is-regex": {
             "version": "1.0.4",
@@ -1532,6 +1945,11 @@
             "requires": {
                 "has": "^1.0.1"
             }
+        },
+        "is-retry-allowed": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
         },
         "is-stream": {
             "version": "1.1.0",
@@ -1556,6 +1974,11 @@
                 "text-extensions": "^1.0.0"
             }
         },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -1571,19 +1994,40 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+        },
         "js-yaml": {
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
             "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+            "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
             }
         },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+        },
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "json-stringify-safe": {
             "version": "5.0.1",
@@ -1602,6 +2046,25 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
             "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "latest-version": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+            "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+            "requires": {
+                "package-json": "^4.0.0"
+            }
         },
         "lcid": {
             "version": "2.0.0",
@@ -1644,42 +2107,50 @@
         "lodash.camelcase": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-            "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+            "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+            "dev": true
         },
         "lodash.kebabcase": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-            "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY="
+            "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
+            "dev": true
         },
         "lodash.merge": {
             "version": "4.6.1",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-            "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+            "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+            "dev": true
         },
         "lodash.mergewith": {
             "version": "4.6.1",
             "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-            "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
+            "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+            "dev": true
         },
         "lodash.omit": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-            "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+            "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
+            "dev": true
         },
         "lodash.pick": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-            "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+            "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+            "dev": true
         },
         "lodash.snakecase": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-            "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40="
+            "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
+            "dev": true
         },
         "lodash.startcase": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
-            "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg="
+            "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg=",
+            "dev": true
         },
         "lodash.template": {
             "version": "4.4.0",
@@ -1701,12 +2172,14 @@
         "lodash.topairs": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
-            "integrity": "sha1-O23qo31g+xFnE8RsXxfqGQ7EjWQ="
+            "integrity": "sha1-O23qo31g+xFnE8RsXxfqGQ7EjWQ=",
+            "dev": true
         },
         "lodash.upperfirst": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
-            "integrity": "sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984="
+            "integrity": "sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=",
+            "dev": true
         },
         "loud-rejection": {
             "version": "1.6.0",
@@ -1717,6 +2190,11 @@
                 "signal-exit": "^3.0.0"
             }
         },
+        "lowercase-keys": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+        },
         "lru-cache": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -1724,6 +2202,14 @@
             "requires": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
+            }
+        },
+        "make-dir": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+            "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+            "requires": {
+                "pify": "^3.0.0"
             }
         },
         "map-age-cleaner": {
@@ -1765,6 +2251,19 @@
                 "trim-newlines": "^2.0.0"
             }
         },
+        "mime-db": {
+            "version": "1.37.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+        },
+        "mime-types": {
+            "version": "2.1.21",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+            "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+            "requires": {
+                "mime-db": "~1.37.0"
+            }
+        },
         "mimic-fn": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
@@ -1790,6 +2289,30 @@
             "requires": {
                 "arrify": "^1.0.1",
                 "is-plain-obj": "^1.1.0"
+            }
+        },
+        "minipass": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+            "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+            "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+                }
+            }
+        },
+        "minizlib": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+            "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+            "requires": {
+                "minipass": "^2.2.1"
             }
         },
         "mkdirp": {
@@ -1845,6 +2368,11 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
         "object-assign": {
             "version": "4.1.1",
@@ -1931,6 +2459,17 @@
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
             "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
         },
+        "package-json": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+            "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+            "requires": {
+                "got": "^6.7.1",
+                "registry-auth-token": "^3.0.1",
+                "registry-url": "^3.0.3",
+                "semver": "^5.1.0"
+            }
+        },
         "parse-github-repo-url": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
@@ -1955,6 +2494,11 @@
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+        },
         "path-key": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -1972,6 +2516,11 @@
             "requires": {
                 "pify": "^3.0.0"
             }
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "pify": {
             "version": "3.0.0",
@@ -2020,9 +2569,9 @@
                     }
                 },
                 "p-limit": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-                    "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+                    "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
                     "dev": true,
                     "requires": {
                         "p-try": "^2.0.0"
@@ -2054,10 +2603,16 @@
                 "semver-compare": "^1.0.0"
             }
         },
+        "prepend-http": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+        },
         "prettier": {
             "version": "1.15.3",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
-            "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg=="
+            "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
+            "dev": true
         },
         "process-nextick-args": {
             "version": "2.0.0",
@@ -2069,6 +2624,11 @@
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
+        "psl": {
+            "version": "1.1.31",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+            "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+        },
         "pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -2079,15 +2639,36 @@
                 "once": "^1.3.1"
             }
         },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
         "q": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
             "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
         },
+        "qs": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
         "quick-lru": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
             "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
+        },
+        "rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            }
         },
         "read-pkg": {
             "version": "3.0.0",
@@ -2134,7 +2715,25 @@
         "regenerator-runtime": {
             "version": "0.11.1",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+            "dev": true
+        },
+        "registry-auth-token": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+            "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+            "requires": {
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "registry-url": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+            "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+            "requires": {
+                "rc": "^1.0.1"
+            }
         },
         "repeating": {
             "version": "2.0.1",
@@ -2142,6 +2741,33 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "requires": {
                 "is-finite": "^1.0.0"
+            }
+        },
+        "request": {
+            "version": "2.88.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
             }
         },
         "require-directory": {
@@ -2152,7 +2778,8 @@
         "require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true
         },
         "require-main-filename": {
             "version": "1.0.1",
@@ -2163,6 +2790,7 @@
             "version": "1.0.3",
             "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+            "dev": true,
             "requires": {
                 "caller-path": "^0.1.0",
                 "resolve-from": "^1.0.0"
@@ -2172,6 +2800,7 @@
                     "version": "0.1.0",
                     "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
                     "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+                    "dev": true,
                     "requires": {
                         "callsites": "^0.2.0"
                     }
@@ -2179,12 +2808,14 @@
                 "callsites": {
                     "version": "0.2.0",
                     "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-                    "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+                    "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+                    "dev": true
                 },
                 "resolve-from": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-                    "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+                    "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+                    "dev": true
                 }
             }
         },
@@ -2206,6 +2837,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-0.1.0.tgz",
             "integrity": "sha1-j7As/Vt9sgEY6IYxHxWvlb0V+9k=",
+            "dev": true,
             "requires": {
                 "global-dirs": "^0.1.0"
             }
@@ -2222,6 +2854,7 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "dev": true,
             "requires": {
                 "glob": "^7.0.5"
             }
@@ -2237,6 +2870,11 @@
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
         "semver": {
             "version": "5.6.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -2247,6 +2885,14 @@
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
             "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
             "dev": true
+        },
+        "semver-diff": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+            "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+            "requires": {
+                "semver": "^5.0.3"
+            }
         },
         "set-blocking": {
             "version": "2.0.0",
@@ -2329,7 +2975,24 @@
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            }
         },
         "standard-version": {
             "version": "4.4.0",
@@ -2604,6 +3267,11 @@
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
             "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
         },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+        },
         "supports-color": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -2632,6 +3300,61 @@
                 "through": "~2.3.8"
             }
         },
+        "tar": {
+            "version": "4.4.8",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+            "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+            "requires": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.4",
+                "minizlib": "^1.1.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+                }
+            }
+        },
+        "term-size": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+            "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+            "requires": {
+                "execa": "^0.7.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "execa": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                    "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+                    "requires": {
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                }
+            }
+        },
         "text-extensions": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -2651,6 +3374,27 @@
                 "xtend": "~4.0.1"
             }
         },
+        "timed-out": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+        },
+        "tough-cookie": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "requires": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+                }
+            }
+        },
         "trim-newlines": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
@@ -2660,6 +3404,19 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
             "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "typedarray": {
             "version": "0.0.6",
@@ -2676,15 +3433,66 @@
                 "source-map": "~0.6.1"
             }
         },
+        "unique-string": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+            "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+            "requires": {
+                "crypto-random-string": "^1.0.0"
+            }
+        },
         "universalify": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         },
+        "unzip-response": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+            "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+        },
+        "update-notifier": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+            "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+            "requires": {
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-ci": "^1.0.10",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
+            }
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "url-parse-lax": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+            "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+            "requires": {
+                "prepend-http": "^1.0.1"
+            }
+        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         },
         "validate-npm-package-license": {
             "version": "3.0.4",
@@ -2693,6 +3501,16 @@
             "requires": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
             }
         },
         "which": {
@@ -2707,6 +3525,14 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+        },
+        "widest-line": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+            "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+            "requires": {
+                "string-width": "^2.1.1"
+            }
         },
         "wordwrap": {
             "version": "0.0.3",
@@ -2746,6 +3572,21 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "write-file-atomic": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+            "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "xdg-basedir": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+            "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
         },
         "xtend": {
             "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
-  "name": "@dhis2/packages",
-  "version": "1.3.0",
-  "description": "Helps manage package links in a monorepo",
-  "bin": "./packages.js",
+  "name": "@dhis2/cli-packages",
+  "version": "2.0.0",
+  "description": "D2 CLI module for managing npm packages",
+  "bin": {
+    "d2-packages": "bin/d2-packages"
+  },
   "scripts": {
     "test": "tape test/**/*",
-    "release": "./packages.js release",
-    "format": "./packages.js code-style"
+    "release": "./bin/d2-packages release",
+    "format": "d2-style js"
   },
   "keywords": [
     "DHIS2",
@@ -15,28 +17,28 @@
     "link",
     "monorepo"
   ],
-  "author": "Viktor Varland",
+  "author": "Viktor Varland <viktor@dhis2.org>",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@dhis2/code-style": "^1.7.1",
+    "@dhis2/cli-helpers-engine": "^0.10.1",
     "@vardevs/io": "^1.5.0",
     "@vardevs/log": "^1.0.0",
     "fs-extra": "^7.0.1",
     "semver": "^5.6.0",
     "standard-version": "^4.4.0",
-    "tape": "^4.9.1",
-    "yargs": "^12.0.5"
+    "tape": "^4.9.1"
   },
   "publishConfig": {
     "access": "public"
   },
   "devDependencies": {
+    "@dhis2/cli-style": "^0.10.1",
     "husky": "^1.2.0"
   },
   "husky": {
     "hooks": {
-      "commit-msg": "./packages.js commit-style",
-      "pre-commit": "./packages.js code-style"
+      "commit-msg": "d2-style commit",
+      "pre-commit": "d2-style js"
     }
   }
 }


### PR DESCRIPTION
This refactor changes `dhis2/packages` to utilize `@dhis2/cli-helpers-engine` under the hood.  This allows it to share CLI interface definition and core configuration options with the rest of the CLI ecosystem.

- The core `packages` functionality has not changed, though `code-style` and `commit-style` commands have been moved to [`d2-style`](https://github.com/dhis2/cli/tree/master/packages/d2-style).  
- The name in `package.json` has been updated to `@dhis2/cli-packages`
- The name of the binary has been changed from `packages` to `d2-packages`
- The version has been reset to `2.0.0` to reflect the breaking change.  **We might want to set this to `1.0.0`**
- This repository should be re-named to `dhis2/cli-packages` or incorporated into the `dhis2/cli` repository.
- Code style and commit style enforcement have been changed to use the `d2-style` CLI 